### PR TITLE
Include NextDNS example .log

### DIFF
--- a/syslog-ng.share/nextdns
+++ b/syslog-ng.share/nextdns
@@ -1,0 +1,18 @@
+ # put NextDNS logs into /opt/var/log/NextDNS.log
+ 
+destination d_nextdns {
+  file("/opt/var/log/NextDNS.log");
+};
+
+filter f_nextdns {
+  program("nextdns");
+};
+ 
+log {
+  source(src);
+  filter(f_nextdns);
+  destination(d_nextdns);
+  flags(final);
+};
+
+#eof


### PR DESCRIPTION
Since many of us are using it, and since NextDNS is very "chatty" in logs, i think i'd be a good idea to include it in logs examples.